### PR TITLE
Added include for errno.h to resolve a compiler error only realized o…

### DIFF
--- a/dirtycow.c
+++ b/dirtycow.c
@@ -1,4 +1,5 @@
 #include <err.h>
+#include <errno.h>
 #include <assert.h>
 #include <dlfcn.h>
 #include <stdio.h>


### PR DESCRIPTION
…n: armeabi-v7a APP_PLATFORM=android-19

OS: Ubuntu 16.10 latest NDK

Fix tested on platforms:
SM-T230NU Tab 4 7" Android 4.42 Acheron Rom (root off)
SM-T800 Tab S 10.5" Android 5.11 CyanogenMod (root off)
SM-N920A Note 5 Android 6.01 pre Nov 1 2016 security patch